### PR TITLE
Feature/conditional to json

### DIFF
--- a/lib/renderror/base_error.rb
+++ b/lib/renderror/base_error.rb
@@ -7,12 +7,12 @@ module Renderror
     end
 
     def to_json
-      {
-        'status' => status,
-        'title' => title,
-        'detail' => detail,
-        'pointer' => pointer
-      }
+      Hash.new.tap do |hash|
+        hash['status'] = status
+        hash['title'] = title
+        hash['detail'] = detail
+        hash['source'] = { 'pointer' => pointer } if pointer
+      end
     end
 
     def status

--- a/lib/renderror/renderer.rb
+++ b/lib/renderror/renderer.rb
@@ -12,7 +12,8 @@ module Renderror
       include RenderInvalidAuthentication
 
       def render_errors(errors)
-        render json: { errors: errors.map(&:to_json) }, status: errors[0].status
+        render json: { errors: Array(errors).map(&:to_json) },
+               status: Array(errors)[0].status
       end
     end
   end

--- a/spec/renderror/bad_request_spec.rb
+++ b/spec/renderror/bad_request_spec.rb
@@ -20,8 +20,7 @@ RSpec.describe Renderror::BadRequest do
       json = {
         'status' => '400',
         'title' => 'Bad Request',
-        'detail' => 'Bad Request',
-        'pointer' => nil
+        'detail' => 'Bad Request'
       }
 
       expect(subject.to_json).to eq json
@@ -45,8 +44,7 @@ RSpec.describe Renderror::BadRequest do
       json = {
         'status' => '400',
         'title' => 'Oops',
-        'detail' => 'Something\'s Not Right',
-        'pointer' => nil
+        'detail' => 'Something\'s Not Right'
       }
 
       expect(subject.to_json).to eq json

--- a/spec/renderror/base_error_spec.rb
+++ b/spec/renderror/base_error_spec.rb
@@ -20,8 +20,7 @@ RSpec.describe Renderror::BaseError do
       json = {
         'status' => '400',
         'title' => 'Bad Request',
-        'detail' => 'Bad Request',
-        'pointer' => nil
+        'detail' => 'Bad Request'
       }
 
       expect(subject.to_json).to eq json
@@ -45,11 +44,28 @@ RSpec.describe Renderror::BaseError do
       json = {
         'status' => '400',
         'title' => 'Oops',
-        'detail' => 'Something\'s Not Right',
-        'pointer' => nil
+        'detail' => 'Something\'s Not Right'
       }
 
       expect(subject.to_json).to eq json
+    end
+  end
+
+  describe '#.to_json' do
+    let(:options) { {} }
+
+    subject { described_class.new(options).to_json }
+
+    it 'only renders present attributes' do
+      expect(subject.keys).to match_array %w[status title detail]
+    end
+
+    context 'when a pointer is present' do
+      before { options[:pointer] = 'pointer' }
+
+      it 'nests the pointer in a source object' do
+        expect(subject['source']['pointer']).to eq 'pointer'
+      end
     end
   end
 end

--- a/spec/renderror/forbidden_spec.rb
+++ b/spec/renderror/forbidden_spec.rb
@@ -21,8 +21,7 @@ RSpec.describe Renderror::Forbidden do
       json = {
         'status' => '403',
         'title' => I18n.t(:"renderror.forbidden.title"),
-        'detail' => I18n.t(:"renderror.forbidden.detail"),
-        'pointer' => nil
+        'detail' => I18n.t(:"renderror.forbidden.detail")
       }
 
       expect(subject.to_json).to eq json
@@ -46,8 +45,7 @@ RSpec.describe Renderror::Forbidden do
       json = {
         'status' => '403',
         'title' => 'Oops',
-        'detail' => 'Something\'s Not Right',
-        'pointer' => nil
+        'detail' => 'Something\'s Not Right'
       }
 
       expect(subject.to_json).to eq json

--- a/spec/renderror/not_found_spec.rb
+++ b/spec/renderror/not_found_spec.rb
@@ -21,8 +21,7 @@ RSpec.describe Renderror::NotFound do
       json = {
         'status' => '404',
         'title' => I18n.t(:"renderror.not_found.title"),
-        'detail' => I18n.t(:"renderror.not_found.detail"),
-        'pointer' => nil
+        'detail' => I18n.t(:"renderror.not_found.detail")
       }
 
       expect(subject.to_json).to eq json
@@ -46,8 +45,7 @@ RSpec.describe Renderror::NotFound do
       json = {
         'status' => '404',
         'title' => 'Oops',
-        'detail' => 'Something\'s Not Right',
-        'pointer' => nil
+        'detail' => 'Something\'s Not Right'
       }
 
       expect(subject.to_json).to eq json

--- a/spec/renderror/unauthorized_spec.rb
+++ b/spec/renderror/unauthorized_spec.rb
@@ -21,8 +21,7 @@ RSpec.describe Renderror::Unauthorized do
       json = {
         'status' => '401',
         'title' => 'Unauthorized',
-        'detail' => 'You need to sign in or sign up before continuing.',
-        'pointer' => nil
+        'detail' => 'You need to sign in or sign up before continuing.'
       }
 
       expect(subject.to_json).to eq json
@@ -46,8 +45,7 @@ RSpec.describe Renderror::Unauthorized do
       json = {
         'status' => '401',
         'title' => 'Oops',
-        'detail' => 'Something\'s Not Right',
-        'pointer' => nil
+        'detail' => 'Something\'s Not Right'
       }
 
       expect(subject.to_json).to eq json

--- a/spec/renderror/unprocessable_entity_spec.rb
+++ b/spec/renderror/unprocessable_entity_spec.rb
@@ -21,8 +21,7 @@ RSpec.describe Renderror::UnprocessableEntity do
       json = {
         'status' => '422',
         'title' => 'Unprocessable Entity',
-        'detail' => 'Unprocessable Entity',
-        'pointer' => nil
+        'detail' => 'Unprocessable Entity'
       }
 
       expect(subject.to_json).to eq json
@@ -46,8 +45,7 @@ RSpec.describe Renderror::UnprocessableEntity do
       json = {
         'status' => '422',
         'title' => 'Oops',
-        'detail' => 'Something\'s Not Right',
-        'pointer' => nil
+        'detail' => 'Something\'s Not Right'
       }
 
       expect(subject.to_json).to eq json


### PR DESCRIPTION
Few small changes here.

Firstly, I've modified the `to_json` method on the base error so that it'll only include a `pointer` if the pointer is actually present.

Secondly, if the aforementioned pointer _is_ present, it's now rendered inside a `source` object, as per the specs [here](http://jsonapi.org/format/#error-objects).

Lastly, the readme suggests rendering a custom error by calling `render_errors(ImATeapot.new)` in the controller, but this raises an exception because `render_errors` expects an array to be passed in. I've modified that method to wrap any arguments in an array, so this will hopefully work now.

Most of the changes are just fixing up the specs that were expecting a `nil` pointer in the output. So, I _think_ that's all okay, let me know what you reckon!