### PR TITLE
Skip adding a pointer for base errors

### DIFF
--- a/lib/renderror/render_unprocessable.rb
+++ b/lib/renderror/render_unprocessable.rb
@@ -13,9 +13,14 @@ module Renderror
         resource.errors.map do |field, error|
           Renderror::UnprocessableEntity.new(
             detail: resource.errors.full_message(field, error),
-            pointer: "/data/attributes/#{field.to_s.dasherize}"
+            pointer: pointer_for(field)
           )
         end
+      end
+
+      def pointer_for(field)
+        return if field == :base
+        "/data/attributes/#{field.to_s.dasherize}"
       end
     end
   end


### PR DESCRIPTION
Tiny change here, just noticed that we are sometimes rendering things like `"source"=>{"pointer"=>"/data/attributes/base"}` which doesn't really make sense. Updated so we skip the pointer for errors on the object `:base`.